### PR TITLE
Use `contextlib.redirect_stdout`

### DIFF
--- a/Memcrashed.py
+++ b/Memcrashed.py
@@ -3,19 +3,17 @@
 import sys, os, time, shodan
 from pathlib import Path
 from scapy.all import *
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 
-starttime=time.time()
+starttime = time.time()
+
 
 @contextmanager
 def suppress_stdout():
     with open(os.devnull, "w") as devnull:
-        old_stdout = sys.stdout
-        sys.stdout = devnull
-        try:  
+        with redirect_stdout(devnull):
             yield
-        finally:
-            sys.stdout = old_stdout
+
 
 class color:
     HEADER = '\033[0m'


### PR DESCRIPTION
https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stdout

```python
>>> from contextlib import contextmanager, redirect_stdout
>>> @contextmanager
... def suppress_stdout():
...     with open(os.devnull, "w") as devnull:
...         old_stdout = sys.stdout
...         sys.stdout = devnull
...         try:
...             yield
...         finally:
...             sys.stdout = old_stdout
... 
>>> with suppress_stdout():
...     print('TEST')
... 
>>> @contextmanager
... def suppress_stdout():
...     with open(os.devnull, "w") as devnull:
...         with redirect_stdout(devnull):
...             yield
... 
>>> with suppress_stdout():
...     print('TEST')
... 

```